### PR TITLE
Fix the log error when a pop operation is detected

### DIFF
--- a/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
+++ b/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
@@ -217,7 +217,7 @@ void PageManager::SwitchTo(PageBase* newNode, bool isPushAct, const PageBase::St
     }
     else
     {
-        PM_LOG_INFO("Page POP is detect, move Page(%s) to foreground", GetPagePrevName());
+        PM_LOG_INFO("Page POP is detect, move Page(%s) to foreground", PageCurrent->Name);
         lv_obj_move_foreground(PageCurrent->root);
         if (PagePrev)lv_obj_move_foreground(PagePrev->root);
     }


### PR DESCRIPTION
Reproduce steps:
1 open the micro of DC_LOG_INFO in DataCenterLog.h
2 run the simulator project
3 click the SystemInfos button to enter the Systeminfo
4 we can see the log "Page POP is detect, move Page(SystemInfos) to foreground"
in the console.
5 click the back button to back to Diaplate
6 However, we get the same log as below. It makes me confusing.

What we need is "PagePOP is detect, move Page(Diaplate) to foreground"