### PR TITLE
make the page can pass parameters to the next page when execute pop

### DIFF
--- a/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
+++ b/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
@@ -72,7 +72,7 @@ PageBase* PageManager::Push(const char* name, const PageBase::Stash_t* stash)
   * @param  None
   * @retval Pointer to the next page 
   */
-PageBase* PageManager::Pop()
+PageBase* PageManager::Pop(const PageBase::Stash_t* stash)
 {
     /* Check whether the animation of switching pages is being executed */
     if (!SwitchAnimStateCheck())
@@ -107,7 +107,7 @@ PageBase* PageManager::Pop()
     if (top != nullptr)
     {
         /* Page switching execution */
-        SwitchTo(top, false, nullptr);
+        SwitchTo(top, false, stash);
     }
 
     return top;

--- a/Software/X-Track/USER/App/Utils/PageManager/PageManager.h
+++ b/Software/X-Track/USER/App/Utils/PageManager/PageManager.h
@@ -113,7 +113,7 @@ public:
 
     /* Router */
     PageBase* Push(const char* name, const PageBase::Stash_t* stash = nullptr);
-    PageBase* Pop();
+    PageBase* Pop(const PageBase::Stash_t* stash = nullptr);
     bool BackHome();
     const char* GetPagePrevName();
 


### PR DESCRIPTION
When we execute the Push action.We can pass the user parameters
the next page by the following code:
Manager->Push("Pages/SystemInfos", &stash_data);

But we can not do the same thing when we use the Pop action.
So I add this code to fix this.