### PR TITLE
Fix typo and page stack root pop

### DIFF
--- a/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
+++ b/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
@@ -140,7 +140,7 @@ bool PageManager::Pop()
 
     if (top == nullptr)
     {
-        PM_LOG_WARN("Page stack is empty, cat't pop");
+        PM_LOG_WARN("Page stack is empty, can't pop");
         return false;
     }
 

--- a/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
+++ b/Software/X-Track/USER/App/Utils/PageManager/PM_Router.cpp
@@ -134,7 +134,12 @@ bool PageManager::Pop()
     {
         return false;
     }
-
+     /*Check if the page is the root page */
+    if (_PageStack.size() <= 1)
+    {
+        PM_LOG_WARN("Only root page remains, can't pop");
+        return false;
+    }
     /* Get the top page of the stack */
     PageBase* top = GetStackTop();
 


### PR DESCRIPTION
- Corrected spelling mistakes.
- fix(page-stack): prevent popping the last root page.
